### PR TITLE
CI: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload test & coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |


### PR DESCRIPTION
Follow-up to #36. Clears the Node 20 deprecation warning on the CI runner by bumping the actions to their current (Node 24-based) majors:

- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `actions/upload-artifact` v4 → v7

No behaviour change — the same inputs are supported, the job still runs `mvn verify` under Xvfb and reports the required `build` status check.